### PR TITLE
Use TLS 1.2 for downloading

### DIFF
--- a/WakaTime.cs
+++ b/WakaTime.cs
@@ -47,6 +47,10 @@ namespace WakaTime
 
             _version = string.Format("{0}.{1}.{2}", CoreAssembly.Version.Major, CoreAssembly.Version.Minor, CoreAssembly.Version.Build);
             _wakaTimeConfigFile = new WakaTimeConfigFile();
+
+            //Use TLS 1.2 for connections to secure resources
+            ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+
         }
 
         /// <summary>Implements the OnConnection method of the IDTExtensibility2 interface. Receives notification that the Add-in is being loaded.</summary>
@@ -60,9 +64,6 @@ namespace WakaTime
 
             try
             {
-
-                //Use TLS 1.2 for connections to secure resources
-                ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
 
                 _applicationObject = (DTE2)application;
                 _addInInstance = (AddIn)addInInst;

--- a/WakaTime.cs
+++ b/WakaTime.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Net;
 using System.Reflection;
 using System.Threading.Tasks;
 using System.Windows.Forms;
@@ -59,6 +60,10 @@ namespace WakaTime
 
             try
             {
+
+                //Use TLS 1.2 for connections to secure resources
+                ServicePointManager.SecurityProtocol = (SecurityProtocolType)3072;
+
                 _applicationObject = (DTE2)application;
                 _addInInstance = (AddIn)addInInst;
 


### PR DESCRIPTION
The plugin crashed for me when trying to download the WakaTime CLI. The problem was that the download didn't use TLS 1.2.
The change I made forces the connections to be made with TLS 1.2.